### PR TITLE
fix java.io.IOException in saving the mapping

### DIFF
--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/resource/ResourceCache.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/resource/ResourceCache.kt
@@ -141,7 +141,8 @@ class ResourceCache(private val input: String, private val libs: List<String>) {
             Logger.info("Writing mappings...")
             if (mappingObjects.isNotEmpty()) {
                 val dir =
-                    "mappings/${SimpleDateFormat("yyyy-MM-dd HH-mm-ss").format(Date())} ${Configs.Settings.input}/"
+                    "mappings/${SimpleDateFormat("yyyy-MM-dd HH-mm-ss").format(Date())}" +
+                            " ${File(Configs.Settings.input).name}/"
                 mappingObjects.forEach { (name, obj) ->
                     obj.saveToFile(File("$dir$name.json"))
                 }


### PR DESCRIPTION
title. If someone writes absolute path for input / output files, then the exception will occur while saving the mapping.