### PR TITLE
Allow LocalVariableRenameTransformer to delete local variables

### DIFF
--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/rename/LocalVariableRenameTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/rename/LocalVariableRenameTransformer.kt
@@ -19,10 +19,11 @@ object LocalVariableRenameTransformer : Transformer("LocalVariableRename", Categ
 
     private val dictionary by setting("Dictionary", "Alphabet")
     private val thisRef by setting("ThisReference", false)
+    private val deleteLocalVars by setting("DeleteLocalVars", false)
     private val exclusion by setting("Exclusion", listOf())
 
     override fun ResourceCache.transform() {
-        Logger.info(" - Renaming local variables...")
+        Logger.info(" - Transforming local variables...")
         val count = count {
             nonExcluded.asSequence()
                 .filter { it.name.notInList(exclusion) }
@@ -33,10 +34,14 @@ object LocalVariableRenameTransformer : Transformer("LocalVariableRename", Categ
                     }
                 }
         }.get()
-        Logger.info("    Renamed $count local variables")
+        Logger.info("    Transformed $count local variables")
     }
 
     override fun transformMethod(owner: ClassNode, method: MethodNode) {
+        if (deleteLocalVars) {
+            method.localVariables?.clear()
+            return
+        }
         val dic = NameGenerator.getByName(dictionary)
         method.localVariables?.forEach {
             if (thisRef || it.name != "this") {

--- a/sample/alien.json
+++ b/sample/alien.json
@@ -188,6 +188,7 @@
     "Enabled": true,
     "Dictionary": "Alphabet",
     "ThisReference": false,
+    "DeleteLocalVars": false,
     "Exclusion": []
   },
   "MethodRename": {


### PR DESCRIPTION
Local variables can now be deleted entirely to further confuse decompilation programs and reduce file size.