### PR TITLE
Implement FlattenSwitch transformer

### DIFF
--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
@@ -109,6 +109,29 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
+            if (tableSwitch) {
+                val newInsn = instructions {
+                    val range = 1..maxSwitchCase.coerceAtLeast(1)
+                    val returnType = Type.getReturnType(methodNode.desc)
+                    methodNode.instructions.forEach { insnNode ->
+                        if (insnNode is JumpInsnNode && insnNode.opcode == Opcodes.GOTO
+                            && Random.nextInt(0, 100) <= switchRate
+                        ) {
+                            +TableSwitch.generate(
+                                insnNode.label,
+                                owner,
+                                methodNode,
+                                returnType,
+                                range.random(),
+                                Random.nextBoolean(),
+                                indyReobf
+                            )
+                            count++
+                        } else +insnNode
+                    }
+                }
+                methodNode.instructions = newInsn
+            }
             if (flattenSwitches) {
                 val newInsn = instructions {
                     methodNode.instructions.forEach { insnNode ->
@@ -165,29 +188,6 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                                 )
                                 count++
                             } else +insnNode
-                        } else +insnNode
-                    }
-                }
-                methodNode.instructions = newInsn
-            }
-            if (tableSwitch) {
-                val newInsn = instructions {
-                    val range = 1..maxSwitchCase.coerceAtLeast(1)
-                    val returnType = Type.getReturnType(methodNode.desc)
-                    methodNode.instructions.forEach { insnNode ->
-                        if (insnNode is JumpInsnNode && insnNode.opcode == Opcodes.GOTO
-                            && Random.nextInt(0, 100) <= switchRate
-                        ) {
-                            +TableSwitch.generate(
-                                insnNode.label,
-                                owner,
-                                methodNode,
-                                returnType,
-                                range.random(),
-                                Random.nextBoolean(),
-                                indyReobf
-                            )
-                            count++
                         } else +insnNode
                     }
                 }

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/FlattenSwitch.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/FlattenSwitch.kt
@@ -22,18 +22,18 @@ object FlattenSwitch {
 
             when (insnNode) {
                 is TableSwitchInsnNode -> {
-                    for ((index, i) in (insnNode.min..insnNode.max).withIndex()) {
+                    for ((index, key) in (insnNode.min..insnNode.max).withIndex()) {
                         ILOAD(slot)
-                        INT(i)
+                        INT(key)
                         IF_ICMPEQ(insnNode.labels[index])
                     }
                     GOTO(insnNode.dflt)
                 }
                 is LookupSwitchInsnNode -> {
-                    for (i in 0 until insnNode.keys.size) {
+                    for (keyIndex in 0 until insnNode.keys.size) {
                         ILOAD(slot)
-                        INT(i)
-                        IF_ICMPEQ(insnNode.labels[i])
+                        INT(keyIndex)
+                        IF_ICMPEQ(insnNode.labels[keyIndex])
                     }
                     GOTO(insnNode.dflt)
                 }

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/FlattenSwitch.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/FlattenSwitch.kt
@@ -1,0 +1,43 @@
+package net.spartanb312.grunt.process.transformers.flow.process
+
+import net.spartanb312.genesis.kotlin.extensions.INT
+import net.spartanb312.genesis.kotlin.extensions.insn.GOTO
+import net.spartanb312.genesis.kotlin.extensions.insn.IF_ICMPEQ
+import net.spartanb312.genesis.kotlin.extensions.insn.ILOAD
+import net.spartanb312.genesis.kotlin.extensions.insn.ISTORE
+import net.spartanb312.genesis.kotlin.instructions
+import org.objectweb.asm.tree.AbstractInsnNode
+import org.objectweb.asm.tree.InsnList
+import org.objectweb.asm.tree.LookupSwitchInsnNode
+import org.objectweb.asm.tree.TableSwitchInsnNode
+
+object FlattenSwitch {
+
+    fun generate(
+        insnNode: AbstractInsnNode,
+        slot: Int
+    ): InsnList {
+        return instructions {
+            ISTORE(slot)
+
+            when (insnNode) {
+                is TableSwitchInsnNode -> {
+                    for ((index, i) in (insnNode.min..insnNode.max).withIndex()) {
+                        ILOAD(slot)
+                        INT(i)
+                        IF_ICMPEQ(insnNode.labels[index])
+                    }
+                    GOTO(insnNode.dflt)
+                }
+                is LookupSwitchInsnNode -> {
+                    for (i in 0 until insnNode.keys.size) {
+                        ILOAD(slot)
+                        INT(i)
+                        IF_ICMPEQ(insnNode.labels[i])
+                    }
+                    GOTO(insnNode.dflt)
+                }
+            }
+        }
+    }
+}

--- a/sample/alien.json
+++ b/sample/alien.json
@@ -114,6 +114,7 @@
     "Enabled": true,
     "Intensity": 1,
     "ExecuteBeforeEncrypt": true,
+    "FlattenSwitchCase": false,
     "BogusConditionJump": true,
     "MangledCompareJump": true,
     "IfReplaceRate": 70,


### PR DESCRIPTION
This transformer flattens/outlines/extracts switch cases:

Example (no other flow transformer enabled; only FlattenSwitchCase):

![image](https://github.com/user-attachments/assets/2df2239b-4c22-40a1-9f3f-cf1df14f63b8)

I believe this is pretty useful, especially when combined with other flow transformers.