### PR TITLE
Implement DeclareFieldsTransformer

### DIFF
--- a/genesis/src/main/kotlin/net/spartanb312/genesis/kotlin/MethodBuilder.kt
+++ b/genesis/src/main/kotlin/net/spartanb312/genesis/kotlin/MethodBuilder.kt
@@ -50,6 +50,14 @@ fun clinit(block: (MethodBuilder.() -> Unit)? = null): MethodNode = method(
 ).apply { if (block != null) modify(block) }
 
 @NodeDSL
+fun init(block: (MethodBuilder.() -> Unit)? = null): MethodNode = method(
+    0,
+    "<init>",
+    "()V", null,
+    null,
+).apply { if (block != null) modify(block) }
+
+@NodeDSL
 fun method(
     access: Modifiers,
     name: String,

--- a/genesis/src/main/kotlin/net/spartanb312/genesis/kotlin/extensions/insn/Constant.kt
+++ b/genesis/src/main/kotlin/net/spartanb312/genesis/kotlin/extensions/insn/Constant.kt
@@ -98,25 +98,10 @@ fun InsnListBuilder.SIPUSH(value: Int) {
 }
 
 /**
- * Push a constant number to the stack
- * -> I/J/F/D
+ * Push any constant object to the stack
  */
 @BuilderDSL
-fun InsnListBuilder.LDC(value: Number) = +LdcInsnNode(value)
-
-/**
- * Push a constant string to the stack
- * -> Ljava/lang/String;
- */
-@BuilderDSL
-fun InsnListBuilder.LDC(string: String) = +LdcInsnNode(string)
-
-/**
- * Push constant class to the stack
- * -> Ljava/lang/Class;
- */
-@BuilderDSL
-fun InsnListBuilder.LDC(type: Type) = +LdcInsnNode(type)
+fun InsnListBuilder.LDC(value: Any) = +LdcInsnNode(value)
 
 @BuilderDSL
 fun InsnListBuilder.LDC_TYPE(typeDesc: String, isArray: Boolean = false) {

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/Transformers.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/Transformers.kt
@@ -40,6 +40,7 @@ object Transformers : MutableList<Transformer> by mutableListOf(
     ClonedClassTransformer order 100,
     TrashClassTransformer order 101,
     HWIDAuthenticatorTransformer order 102,
+    DeclareFieldsTransformer order 103,
     ReflectionSupportTransformer order 199,
     //ControlflowTransformer order 200,
     StringEncryptTransformer order 300,

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/misc/DeclareFieldsTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/misc/DeclareFieldsTransformer.kt
@@ -1,0 +1,88 @@
+package net.spartanb312.grunt.process.transformers.misc
+
+import net.spartanb312.genesis.kotlin.clinit
+import net.spartanb312.genesis.kotlin.extensions.INT
+import net.spartanb312.genesis.kotlin.extensions.LONG
+import net.spartanb312.genesis.kotlin.extensions.insn.BIPUSH
+import net.spartanb312.genesis.kotlin.extensions.insn.LDC
+import net.spartanb312.genesis.kotlin.extensions.insn.PUTFIELD
+import net.spartanb312.genesis.kotlin.extensions.insn.PUTSTATIC
+import net.spartanb312.genesis.kotlin.extensions.insn.SIPUSH
+import net.spartanb312.genesis.kotlin.init
+import net.spartanb312.genesis.kotlin.instructions
+import net.spartanb312.grunt.config.setting
+import net.spartanb312.grunt.process.Transformer
+import net.spartanb312.grunt.process.resource.ResourceCache
+import net.spartanb312.grunt.utils.count
+import net.spartanb312.grunt.utils.extensions.isAnnotation
+import net.spartanb312.grunt.utils.logging.Logger
+import net.spartanb312.grunt.utils.notInList
+import org.objectweb.asm.Opcodes.RETURN
+import org.objectweb.asm.tree.ClassNode
+import org.objectweb.asm.tree.FieldNode
+import org.objectweb.asm.tree.InsnList
+import org.objectweb.asm.tree.InsnNode
+import java.lang.reflect.Modifier
+
+/**
+ * Fields will be — instead of the field having a constant value —
+ * initialized in the '<clinit>' or '<init>' of the respective class.
+ * This allows other transformers to transform these final fields.
+ *
+ * @author jonesdevelopment
+ */
+object DeclareFieldsTransformer : Transformer("HideDeclaredFields", Category.Miscellaneous) {
+
+    private val exclusion by setting("Exclusion", listOf())
+
+    override fun ResourceCache.transform() {
+        Logger.info(" - Hiding declared fields...")
+        val count = count {
+            nonExcluded.asSequence()
+                .filter { !it.isAnnotation && it.name.notInList(exclusion) }
+                .forEach { classNode ->
+                    var clinit = classNode.methods.firstOrNull { it.name.equals("<clinit>") }
+                    var init = classNode.methods.firstOrNull { it.name.equals("<init>") }
+                    for (field in classNode.fields) {
+                        if (field.value != null) {
+                            if (Modifier.isStatic(field.access)) {
+                                if (clinit == null) {
+                                    clinit = clinit()
+                                    clinit.instructions.add(InsnNode(RETURN))
+                                    classNode.methods.add(clinit)
+                                }
+                                clinit.instructions.insert(box(classNode, field, true))
+                            } else {
+                                if (init == null) {
+                                    init = init()
+                                    init.instructions.add(InsnNode(RETURN))
+                                    classNode.methods.add(init)
+                                }
+                                init.instructions.insert(box(classNode, field, false))
+                            }
+                            field.value = null
+                            add()
+                        }
+                    }
+                }
+        }.get()
+        Logger.info("    Hid $count declared fields")
+    }
+
+    fun box(owner: ClassNode, field: FieldNode, static: Boolean): InsnList {
+        return instructions {
+            when (field.desc) {
+                "I" -> INT(field.value as Int)
+                "J" -> LONG(field.value as Long)
+                "B" -> BIPUSH(field.value as Int)
+                "S" -> SIPUSH(field.value as Int)
+                else -> LDC(field.value)
+            }
+            if (static) {
+                PUTSTATIC(owner.name, field.name, field.desc)
+            } else {
+                PUTFIELD(owner.name, field.name, field.desc)
+            }
+        }
+    }
+}

--- a/sample/alien.json
+++ b/sample/alien.json
@@ -262,6 +262,10 @@
     "Exceptions": true,
     "Exclusion": []
   },
+  "HideDeclaredFields": {
+    "Enabled": true,
+    "Exclusion": []
+  },
   "Crasher": {
     "Enabled": false,
     "Random": false,


### PR DESCRIPTION
Declares fields that have constant values:

```java
private static final int a = 1;
private static final int b = 2;
private static final int c = 3;
```
turns into
```java
private static final int a;
private static final int b;
private static final int c;

static {
  a = 1;
  b = 2;
  c = 3;
}
```
This makes it possible to harden the obfuscation of constants (by allowing other transformers to access these values since they'd normally only be accessible through `field.value`).