### PR TITLE
Improve jump flow obfuscation

### DIFF
--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
@@ -113,7 +113,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
-            if (mutateJumps) { // step3: replace jumps with table switches
+            if (mutateJumps) { // step2: replace jumps with table switches
                 methodNode.instructions = instructions {
                     methodNode.instructions.forEach { instruction ->
                         if (instruction is JumpInsnNode
@@ -125,7 +125,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                     }
                 }
             }
-            if (switchExtractor) { // step2: extract switches { switch: m, if: n2 = n + Σ(0->m) cases }
+            if (switchExtractor) { // step3: extract switches { switch: m, if: n2 = n + Σ(0->m) cases }
                 val newInsn = instructions {
                     methodNode.instructions.forEach { insnNode ->
                         if (insnNode is TableSwitchInsnNode || insnNode is LookupSwitchInsnNode) {
@@ -139,7 +139,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
-            if (bogusJump) { // step3: replace goto { goto: l1 = l - dl, if: n3 = n2 + dl }
+            if (bogusJump) { // step4: replace goto { goto: l1 = l - dl, if: n3 = n2 + dl }
                 val newInsn = instructions {
                     val returnType = Type.getReturnType(methodNode.desc)
                     methodNode.instructions.forEach { insnNode ->
@@ -160,7 +160,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
-            if (mangledIf) { // step4: process if opcode { if: n4 ≈ n3 + dn * 2, goto: l2 ≈ l1 + dn * 2 }
+            if (mangledIf) { // step5: process if opcode { if: n4 ≈ n3 + dn * 2, goto: l2 ≈ l1 + dn * 2 }
                 val newInsn = instructions {
                     val returnType = Type.getReturnType(methodNode.desc)
                     methodNode.instructions.forEach { insnNode ->
@@ -186,7 +186,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
-            if (tableSwitch) { // step5: replace goto to switch { switch: m2 = m + E(case) * l2 * rate }
+            if (tableSwitch) { // step6: replace goto to switch { switch: m2 = m + E(case) * l2 * rate }
                 val newInsn = instructions {
                     val range = 1..maxSwitchCase.coerceAtLeast(1)
                     val returnType = Type.getReturnType(methodNode.desc)

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/ControlflowTransformer.kt
@@ -39,7 +39,7 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
     private val ifCompareRate by setting("IfICompareReplaceRate", 100) // Range 0..100
     private val switchProtect by setting("SwitchProtect", true)
     private val tableSwitch by setting("TableSwitchJump", true)
-    private val rearrangeJumps by setting("RearrangeJumps", true)
+    private val mutateJumps by setting("MutateJumps", true)
     private val switchRate by setting("SwitchReplaceRate", 30)  // Range 0..100
     private val maxSwitchCase by setting("MaxSwitchCase", 5) // Range 1..10
     val reverseExistedIf by setting("ReverseExistedIf", true)
@@ -113,13 +113,13 @@ object ControlflowTransformer : Transformer("Controlflow", Category.Controlflow)
                 }
                 methodNode.instructions = newInsn
             }
-            if (rearrangeJumps) { // step3: replace jumps with table switches
+            if (mutateJumps) { // step3: replace jumps with table switches
                 methodNode.instructions = instructions {
                     methodNode.instructions.forEach { instruction ->
                         if (instruction is JumpInsnNode
                             && instruction.opcode != Opcodes.GOTO
                             && !instruction.previous.isDummy) {
-                            +RearrangeJumps.generate(instruction)
+                            +MutateJumps.generate(instruction)
                             count++
                         } else +instruction
                     }

--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/RearrangeJumps.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/flow/process/RearrangeJumps.kt
@@ -1,0 +1,60 @@
+package net.spartanb312.grunt.process.transformers.flow.process
+
+import net.spartanb312.genesis.kotlin.extensions.INT
+import net.spartanb312.genesis.kotlin.extensions.LABEL
+import net.spartanb312.genesis.kotlin.extensions.insn.*
+import net.spartanb312.genesis.kotlin.instructions
+import org.objectweb.asm.tree.InsnList
+import org.objectweb.asm.tree.JumpInsnNode
+import org.objectweb.asm.tree.LabelNode
+import kotlin.random.Random
+
+/**
+ * Idea taken from https://github.com/willemml/binscure
+ *
+ * @author jonesdevelopment
+ */
+object RearrangeJumps {
+
+    fun generate(
+        jump: JumpInsnNode
+    ): InsnList {
+        return instructions {
+            val trueLabel = LabelNode()
+            val proxyTrue = LabelNode()
+            val switchLabel = LabelNode()
+            val falseGoto = LabelNode()
+
+            val random = Random.nextInt() and 0xFFFF
+
+            +JumpInsnNode(jump.opcode, trueLabel)
+            +obfuscate(random - 1)
+            GOTO(switchLabel)
+            LABEL(trueLabel)
+            +obfuscate(random)
+            GOTO(switchLabel)
+            LABEL(proxyTrue)
+            NOP
+            +obfuscate(random - 2)
+            LABEL(switchLabel)
+            TABLESWITCH(random - 1, random, jump.label, falseGoto, proxyTrue)
+            LABEL(falseGoto)
+        }
+    }
+
+    fun obfuscate(v: Int): InsnList {
+        return instructions {
+            val add = Random.nextBoolean()
+            val key = Random.nextInt(v)
+            if (add) {
+                INT(v - key)
+                INT(key)
+                IADD
+            } else {
+                INT(v + key)
+                INT(key)
+                ISUB
+            }
+        }
+    }
+}


### PR DESCRIPTION
I saw something similar to this in binscure and implemented a similar version of it.

This is the result of this transformer in combination with the switch extractor:
![image](https://github.com/user-attachments/assets/fb4ab9bc-6503-4195-94b4-f2e6a2453bab)

Without switch protector and anything else (this is not the same method as the one from the screenshot above):
![image](https://github.com/user-attachments/assets/576de718-280c-4592-83ce-578200069242)

CFR hates this...

@SpartanB312 Please test this with some more samples whenever you have time.