### PR TITLE
Fix arithmetic instruction replacement errors

### DIFF
--- a/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/encrypt/ArithmeticEncryptTransformer.kt
+++ b/grunt-main/src/main/kotlin/net/spartanb312/grunt/process/transformers/encrypt/ArithmeticEncryptTransformer.kt
@@ -84,7 +84,7 @@ object ArithmeticEncryptTransformer : Transformer("ArithmeticEncrypt", Category.
                     val next = methodNode.instructions[index + 1]
                     val nextNext = methodNode.instructions[index + 2]
                     when {
-                        insn.opcode == Opcodes.ICONST_M1 && next.opcode == Opcodes.IXOR && nextNext.opcode == Opcodes.IADD -> {
+                        insn.opcode == Opcodes.ICONST_M1 && next.opcode == Opcodes.IXOR && nextNext.opcode == Opcodes.IAND -> {
                             if (Random.nextBoolean()) {
                                 DUP_X1
                                 IOR


### PR DESCRIPTION
before
iconst_m1 - ixor - iadd => dup_x1 - ior - swap - isub
now
iconst_m1 - ixor - iand => dup_x1 - ior - swap - isub

In recaf, edit a class file, then you can verify why it is correct

The original replacement output would be 10 and 4, which is obviously incorrect.

```java

iconst_5
istore a
bipush 10
istore b
getstatic java/lang/System.out Ljava/io/PrintStream;
iload b
iload a

iconst_m1
ixor
iadd

invokevirtual java/io/PrintStream.println (I)V
getstatic java/lang/System.out Ljava/io/PrintStream;
iload b
iload a

dup_x1
ior
swap 
isub

invokevirtual java/io/PrintStream.println (I)V
return

```

in my fix version, replace iadd with iand, then it will be right. 

```java

iconst_5
istore a
bipush 10
istore b
getstatic java/lang/System.out Ljava/io/PrintStream;
iload b
iload a

iconst_m1
ixor
iand

invokevirtual java/io/PrintStream.println (I)V
getstatic java/lang/System.out Ljava/io/PrintStream;
iload b
iload a

dup_x1
ior
swap 
isub

invokevirtual java/io/PrintStream.println (I)V
return

```
